### PR TITLE
MAPEX-44: Add Draft ATT&CK Mappings JSON Schema

### DIFF
--- a/schema/mapex-unified-data-schema.json
+++ b/schema/mapex-unified-data-schema.json
@@ -10,11 +10,11 @@
             "properties": {
                 "mapping_version": {
                     "description": "The version of the mapping project.",
-                    "type": "number"
+                    "type": "string"
                 },
                 "attack_version": {
                     "description": "The version of ATT&CK used to source the objects included in this mapping.",
-                    "type": "number"
+                    "type": "string"
                 },
                 "technology_domain": {
                     "description": "ATT&CK Technology Domain (Enterprise, Mobile, ICS).",
@@ -78,7 +78,7 @@
                     "type": "string"
                 },
                 "mapping_types": {
-                    "description": "The mappings file valid mapping types.",
+                    "description": "The mappings types that are associated with each Framework.",
                     "type": "array",
                     "items": {
                         "type": "object",
@@ -106,7 +106,7 @@
             ]
         },
         "mapping_object": {
-            "description": "The mappings between framework objects and ATT&CK objects.",
+            "description": "A single mapping between framework object and ATT&CK object.",
             "type": "array",
             "items": {
                 "type": "object",
@@ -116,15 +116,15 @@
                         "type": "string"
                     },
                     "attack_object_name": {
-                        "description": "The name of the ATT&CK Object. (Serverless Execution)",
+                        "description": "The name of the ATT&CK object. (Serverless Execution)",
                         "type": "string"
                     },
                     "capability_id": {
                         "description": "Unique identifier of the framework object being mapped.",
                         "type": "string"
                     },
-                    "mapping_description": {
-                        "description": "Name or description of Mapping Target",
+                    "capability_description": {
+                        "description": "Name or description of framework object",
                         "type": "string"
                     },
                     "comments": {
@@ -181,7 +181,10 @@
                 "required": [
                     "mapping_type",
                     "capability_id"
-                ]
+                ],
+                "dependentRequired":{
+                    "mapping_type":["valid_mapping_types"]
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #44

## What Changed
Adds draft ATT&CK Mappings JSON Schema.

## Limitations
The unified schema is still not fully settled. As a result, some fields of the JSON schema are tentative.  