### PR TITLE
MAPEX 154: when no results, don't show attack version select

### DIFF
--- a/src/mappings_explorer/templates/search.html.j2
+++ b/src/mappings_explorer/templates/search.html.j2
@@ -39,7 +39,7 @@
         </section>
         <div class="loader" v-if="loading"></div>
         <div class="container" data-aos="fade-up">
-          <form class="col-12 version-select">
+          <form class="col-12 version-select" v-if="results && results.results && results.results.length">
             <div class="row col-12" style="display: flex;">
               <div class="col-md-2 col-sm-4 form-group" @focusout="handleOutsideClick" tabindex="-1">
                 <p>ATT&CK Version</p>
@@ -204,12 +204,7 @@
        * create an array with all attack versions that appear in the results
        */
       getAttackVersionsInResults(){
-        let attackVersions = [];
-        if (!this.results.results.length) {
-          this.selectedAttackVersion = "All Versions";
-          this.attackVersionsInResults = ["All Versions"];
-        }
-        else {
+        if (this.results.results.length) {
           this.results.results.forEach(result => {
             let attackVersion = this.getStringFromUrl(result.ref, "attack-");
             !attackVersions.includes(attackVersion) && attackVersions.push(attackVersion);
@@ -247,7 +242,6 @@
         return returnString
       },
       handleItemPerPageChange(){
-        console.log("IN HERE!")
         this.pageNum = 1;
       },
       /**


### PR DESCRIPTION
**What changed**
- When there are no search results, the ATT&CK version select does not appear