### PR TITLE
remove attack link from mapping framework landing pages

### DIFF
--- a/src/mappings_explorer/templates/framework_landing.html.j2
+++ b/src/mappings_explorer/templates/framework_landing.html.j2
@@ -12,7 +12,6 @@
           <p>
             {{- description -}}
           </p>
-          <a href="https://attack.mitre.org/" target="_blank">View in MITRE ATT&CK®</a>
           {% for resource in project.resources %}
             <p>
               <a class="link" href="{{url_prefix}}{{resource.link}}">


### PR DESCRIPTION
# What changed
- `View in MITRE ATT&CK` link to `attack.mitre.org` removed from mapping framework landing pages