### PR TITLE
MAPEX(292): separate production build and preview build

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -1,0 +1,111 @@
+name: Build Website
+
+on:
+  pull_request:
+
+# If another web build starts for the same branch, cancel the previous build. This
+# protects us from two builds trying to upload at the same time and clobbering each
+# other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  id-token: write
+  pages: write
+  pull-requests: write
+
+jobs:
+  build_preview:
+    runs-on: ubuntu-latest
+    env:
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+      LOGURU_LEVEL: DEBUG
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+            version: 1.8.5
+      - name: Collect Error Logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs
+          path: /home/runner/work/**/*.log
+      - name: Add Poetry to PATH
+        run: echo "$HOME/.poetry/bin" >> $GITHUB_PATH
+      - name: Install dependencies
+        run: poetry install
+      - name: Build Web Site
+        run: poetry run build-mappings-explorer --url-prefix 'https://mappingsexplorer.z13.web.core.windows.net/${{env.BRANCH_NAME}}/'
+      - name: Export Download Artifacts
+        run: poetry run mapex export ${GITHUB_WORKSPACE}/mappings ${GITHUB_WORKSPACE}/output/data
+      - name: Compress Artifacts
+        run: zip -rq output.zip output/
+      - name: Upload Web Site
+        uses: actions/upload-artifact@v4
+        with:
+          name: mapex-web-preview
+          path: output.zip
+
+  # Publish to Azure blob only on PRs, not main.
+  azure_blob:
+    if: github.ref_name != 'main'
+    needs: build_preview
+    runs-on: ubuntu-latest
+    env:
+      AZURE_STORAGE_ACCOUNT: mappingsexplorer
+      AZURE_STORAGE_SAS_TOKEN: ${{ secrets.AZURE_SAS_TOKEN }}
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+      STATICRYPT_PASS: ${{ secrets.STATICRYPT_PASS }}
+    steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+      - run: npm install -g staticrypt
+      - name: Download Web Site
+        uses: actions/download-artifact@v4
+        with:
+          name: mapex-web-preview
+          path: .
+      - name: Decompress Artifacts
+        run: unzip -q output.zip
+      - env:
+          STATICRYPT_PASS: ${{ secrets.STATICRYPT_PASS }}
+          NODE_OPTIONS: --max-old-space-size=8192
+        run: >
+          staticrypt --remember 30 --salt c0c22fdf0cd9d2a099db9c90ca4a58bf \
+            --password $STATICRYPT_PASS --short \
+            --template-title "Mappings Explorer (branch: $BRANCH_NAME)" \
+            --template-instructions "The contents of this site are marked TLP:AMBER:CTID-R&D:22-80. Do not share with unauthorized individuals." \
+            --template-color-primary "#6241c5" \
+            --template-color-secondary "#b2b2b2" \
+            --template-button "Log In" \
+            -r output/
+      - name: Ensure StatiCrypt ran # StatiCrypt will fail without warning; verify it created a directory
+        run: test -d encrypted
+      - name: Copy encrypted HTML files
+        run: rsync -Ir -v --include='*.html' --exclude='*.*' encrypted/output .
+      - name: Set the branch name
+        run: mv output "$BRANCH_NAME"
+      - name: Install Azure CLI
+        run: curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+      - name: Delete old blobs
+        run: az storage blob delete-batch -s '$web' --pattern "$BRANCH_NAME/*"
+      - name: Upload to blob storage
+        run: az storage blob upload-batch -s . --pattern "$BRANCH_NAME/*" -d '$web'
+      - uses: actions/github-script@v6
+        if: github.event_name == 'pull_request'
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `This PR has been published to https://mappingsexplorer.z13.web.core.windows.net/${process.env['BRANCH_NAME']}/`,
+            })

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -3,7 +3,6 @@ name: Build Website
 on:
   push:
     branches: [main]
-  pull_request:
 
 # If another web build starts for the same branch, cancel the previous build. This
 # protects us from two builds trying to upload at the same time and clobbering each
@@ -44,7 +43,6 @@ jobs:
       - name: Install dependencies
         run: poetry install
       - name: Build Web Site
-        # run: poetry run build-mappings-explorer --url-prefix 'https://mappingsexplorer.z13.web.core.windows.net/${{env.BRANCH_NAME}}/'
         run: poetry run build-mappings-explorer --url-prefix 'https://center-for-threat-informed-defense.github.io/mappings-explorer/'
       - name: Export Download Artifacts
         run: poetry run mapex export ${GITHUB_WORKSPACE}/mappings ${GITHUB_WORKSPACE}/output/data
@@ -55,63 +53,6 @@ jobs:
         with:
           name: mapex-web
           path: output.zip
-
-  #Publish to Azure blob only on PRs, not main.
-  # azure_blob:
-  #   if: github.ref_name != 'main'
-  #   needs: web_site
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     AZURE_STORAGE_ACCOUNT: mappingsexplorer
-  #     AZURE_STORAGE_SAS_TOKEN: ${{ secrets.AZURE_SAS_TOKEN }}
-  #     BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-  #     STATICRYPT_PASS: ${{ secrets.STATICRYPT_PASS }}
-  #   steps:
-  #     - uses: actions/setup-node@v3
-  #       with:
-  #         node-version: "18"
-  #     - run: npm install -g staticrypt
-  #     - name: Download Web Site
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: mapex-web
-  #         path: .
-  #     - name: Decompress Artifacts
-  #       run: unzip -q output.zip
-  #     - env:
-  #         STATICRYPT_PASS: ${{ secrets.STATICRYPT_PASS }}
-  #         NODE_OPTIONS: --max-old-space-size=8192
-  #       run: >
-  #         staticrypt --remember 30 --salt c0c22fdf0cd9d2a099db9c90ca4a58bf \
-  #           --password $STATICRYPT_PASS --short \
-  #           --template-title "Mappings Explorer (branch: $BRANCH_NAME)" \
-  #           --template-instructions "The contents of this site are marked TLP:AMBER:CTID-R&D:22-80. Do not share with unauthorized individuals." \
-  #           --template-color-primary "#6241c5" \
-  #           --template-color-secondary "#b2b2b2" \
-  #           --template-button "Log In" \
-  #           -r output/
-  #     - name: Ensure StatiCrypt ran # StatiCrypt will fail without warning; verify it created a directory
-  #       run: test -d encrypted
-  #     - name: Copy encrypted HTML files
-  #       run: rsync -Ir -v --include='*.html' --exclude='*.*' encrypted/output .
-  #     - name: Set the branch name
-  #       run: mv output "$BRANCH_NAME"
-  #     - name: Install Azure CLI
-  #       run: curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-  #     - name: Delete old blobs
-  #       run: az storage blob delete-batch -s '$web' --pattern "$BRANCH_NAME/*"
-  #     - name: Upload to blob storage
-  #       run: az storage blob upload-batch -s . --pattern "$BRANCH_NAME/*" -d '$web'
-  #     - uses: actions/github-script@v6
-  #       if: github.event_name == 'pull_request'
-  #       with:
-  #         script: |
-  #           github.rest.issues.createComment({
-  #             issue_number: context.issue.number,
-  #             owner: context.repo.owner,
-  #             repo: context.repo.repo,
-  #             body: `This PR has been published to https://mappingsexplorer.z13.web.core.windows.net/${process.env['BRANCH_NAME']}/`,
-  #           })
 
   github_pages:
     # This job only runs when committing or merging to main branch.


### PR DESCRIPTION
Note from Jira: 

(We may not want to push out a new MapEx build for each push to main, which is how ctid-web works; we could trigger the build workflow on pushing a tag instead. The Attack Flow project works like that.)

Currently, I have this configured to build to production for each push to main, but we can change that.